### PR TITLE
Use sparticuz chrome package for node 18 lts support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.1.0] - 2023-05-30
+
+### Changed
+
+- Replaced chrome-aws-lambda dependency with updated package for Node LTS support

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const chrome = require('chrome-aws-lambda');
+const chrome = require('@sparticuz/chromium');
 const puppeteer = require('puppeteer');
 
 const { createInstance } = require('./instance');
@@ -23,7 +23,7 @@ module.exports.createInstance = async ({
       ...browserArgs,
     ],
     defaultViewport: chrome.defaultViewport,
-    executablePath: await chrome.executablePath,
+    executablePath: await chrome.executablePath(),
     headless: true,
     ignoreHTTPSErrors: true,
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polotno-node",
-  "version": "2.0.7",
+  "version": "2.1.0",
   "description": "Polotno workflow from NodeJS",
   "main": "index.js",
   "scripts": {
@@ -26,7 +26,7 @@
   "author": "Anton Lavrenov",
   "license": "MIT",
   "dependencies": {
-    "chrome-aws-lambda": "^10.1.0",
+    "@sparticuz/chromium": "111.0.0",
     "puppeteer": "^19.7.5"
   },
   "bugs": {


### PR DESCRIPTION
### Description

Based on [issue](https://github.com/polotno-project/polotno-node/issues/3), chrome-aws-lambda is no longer updated and doesn't support node lts (18) anymore. 

Replaced chrome-aws-lambda with [chromium](https://github.com/Sparticuz/chromium) for node 18/lts support. That repo is regularly updated so it can deal with future node updates as well. 

Also added changelog to make it obvious what changed on the version update. 