### PR TITLE
Add requestInterceptor callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,6 +107,7 @@ module.exports.createInstance = async ({
   useParallelPages,
   browserArgs = [],
   browser,
+  requestInterceptor,
 } = {}) => {
   return await createInstance({
     browser: browser || (await createBrowser({ browserArgs })),
@@ -114,5 +115,6 @@ module.exports.createInstance = async ({
     url,
     useParallelPages,
     browserArgs,
+    requestInterceptor,
   });
 };


### PR DESCRIPTION
This pull request introduces a new feature to support request interception when creating browser pages. The changes primarily involve passing a `requestInterceptor` function through the relevant methods and ensuring it is correctly applied to browser pages.

### Request Interception Feature:

* [`index.js`](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346R110-R118): Added a `requestInterceptor` parameter to the `createInstance` function, passing it along to the internal `createInstance` call.
* [`instance.js`](diffhunk://#diff-4d17d7205b7f696032d305738184c05ed3fb1e1dd9c8d5544266210c0e2ededcL4-R12): Updated the `createPage` function to accept a `requestInterceptor` parameter. If provided, it enables request interception on the browser page and attaches the interceptor function to the `request` event.
* [`instance.js`](diffhunk://#diff-4d17d7205b7f696032d305738184c05ed3fb1e1dd9c8d5544266210c0e2ededcR98-R107): Modified the `createInstance` function to pass the `requestInterceptor` parameter when calling `createPage`, ensuring the interceptor is applied consistently across all page creation scenarios. [[1]](diffhunk://#diff-4d17d7205b7f696032d305738184c05ed3fb1e1dd9c8d5544266210c0e2ededcR98-R107) [[2]](diffhunk://#diff-4d17d7205b7f696032d305738184c05ed3fb1e1dd9c8d5544266210c0e2ededcL310-R317)